### PR TITLE
ci: upgrade to Calcit 0.13.13

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -13,7 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: calcit-lang/setup-cr@0.0.8
+      - uses: calcit-lang/setup-cr@0.0.9
+        with:
+          version: "0.13.13"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -25,4 +27,4 @@ jobs:
 
       - run: rm -rfv dylibs/* && mkdir -p dylibs/ && ls target/release/ && cp -v target/release/*.* dylibs/
 
-      - run: cr
+      - run: caps --ci && cr

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
 {}
-  :calcit-version |0.12.46
+  :calcit-version |0.13.13
   :deps $ []


### PR DESCRIPTION
Updates setup-cr to 0.0.9 and pins Calcit 0.13.13. The CI check now runs `caps --ci` before `cr`, exercising project-scoped dependency installation.\n\nValidated locally with Calcit 0.13.13:\n- `caps --ci`\n- `cr`\n- `cargo build --release`