### PR TITLE
chore: complete Calcit project upgrade

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 
-calcit.cirru -diff linguist-generated
 Cargo.lock -diff linguist-generated

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,6 +17,15 @@ jobs:
         with:
           version: "0.13.13"
 
+      - name: Validate Calcit snapshot and types
+        run: |
+          caps --ci
+          cr calcit.cirru edit format
+          git diff --exit-code -- calcit.cirru
+          cr calcit.cirru --check-only
+          cr calcit.cirru analyze check-types --summary-only --format json
+          cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only --format json
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
@@ -27,4 +36,4 @@ jobs:
 
       - run: rm -rfv dylibs/* && mkdir -p dylibs/ && ls target/release/ && cp -v target/release/*.* dylibs/
 
-      - run: caps --ci && cr
+      - run: cr calcit.cirru

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 .calcit-error.cirru
 .compact-inc.cirru
+compact.cirru
 
 /dylibs/
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The callback should return a response map with:
 
 Install with `caps add calcit-lang/http@<tag>` and run `caps`. The project-local
 `.calcit/modules/` view points at the versioned global module store. Compile and provide
-the matching `*.{dylib,so}` file with `./build.sh`.
+the matching `*.{dylib,so,dll}` file with `./build.sh`.
 
 ### Workflow
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ The callback should return a response map with:
 - `:headers` - map of header name to string value
 - `:body` - response body string
 
-Install to `~/.config/calcit/modules/`, compile and provide `*.{dylib,so}` file with `./build.sh`.
+Install with `caps add calcit-lang/http@<tag>` and run `caps`. The project-local
+`.calcit/modules/` view points at the versioned global module store. Compile and provide
+the matching `*.{dylib,so}` file with `./build.sh`.
 
 ### Workflow
 

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -65,7 +65,9 @@
                 :headers $ {} (:content-type |application/json)
                 :body $ format-cirru-edn req
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ [] 'Dynamic
         |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ println |Reload

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,14 +1,16 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |http)
-  :configs $ {} (:init-fn |http.test/main!) (:reload-fn |http.test/reload!) (:version |0.3.1)
-    :modules $ []
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |http) (:version |0.3.1)
   :entries $ {}
-    :server $ {} (:init-fn |http.test/demo-server!) (:reload-fn |http.test/reload!) (:version |0.0.0)
+    :default $ {} (:description |) (:init-fn 'http.test/main!) (:mode :native) (:reload-fn 'http.test/reload!)
       :modules $ []
+      :type-slots $ {}
+    :server $ {} (:description |) (:init-fn 'http.test/demo-server!) (:mode :native) (:reload-fn 'http.test/reload!)
+      :modules $ []
+      :type-slots $ {}
   :files $ {}
-    |http.core $ %{} :FileEntry
+    |http.core $ %{} 'FileEntry
       :defs $ {}
-        |serve-http! $ %{} :CodeEntry (:doc "|Starts a native HTTP server through the Rust dylib. Params: options (nil or map with :port and :host), f (request handler receiving a request map and returning a response map). Returns: unit while server loop runs.")
+        |serve-http! $ %{} 'CodeEntry (:doc "|Starts a native HTTP server through the Rust dylib. Params: options (nil or map with :port and :host), f (request handler receiving a request map and returning a response map). Returns: unit while server loop runs.")
           :code $ quote
             defn serve-http! (options f)
               &call-dylib-edn-fn (get-dylib-path |/dylibs/libcalcit_http) |serve_http options f
@@ -19,71 +21,96 @@
                 {} (:code 200)
                   :headers $ {} (:content-type |application/json)
                   :body |ok
-          :schema $ :: :fn
-            {} (:return :unit)
-              :args $ [] :dynamic
-                :: :fn $ {} (:return :dynamic)
-                  :args $ [] :dynamic
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ [] 'Dynamic
+                :: 'Fn $ {} (:return 'Dynamic)
+                  :args $ [] 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns http.core $ :require
             http.$meta :refer $ calcit-dirname
             http.util :refer $ get-dylib-path
-    |http.test $ %{} :FileEntry
+    |http.test $ %{} 'FileEntry
       :defs $ {}
-        |demo-server! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |demo-server! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn demo-server! () $ serve-http!
               {} $ :port 4000
               fn (req) (on-request req)
           :examples $ []
-        |main! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ run-tests
           :examples $ []
-        |mid-call $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+        |mid-call $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn mid-call () $ println "|Calling internal function"
           :examples $ []
-        |on-request $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+        |on-request $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn on-request (req) (; println "|Handling request:" req)
-              println $ :url req
+              println $ get req :url
               ; mid-call
               {} (:status :ok) (:code 200)
                 :headers $ {} (:content-type |application/json)
                 :body $ format-cirru-edn req
           :examples $ []
-        |reload! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ println |Reload
           :examples $ []
-        |run-tests $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+        |run-tests $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn run-tests () (println "|%%%% test for lib") (println calcit-filename calcit-dirname) (println "|No tests...")
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns http.test $ :require
             http.core :refer $ serve-http!
             http.$meta :refer $ calcit-dirname calcit-filename
-    |http.util $ %{} :FileEntry
+    |http.util $ %{} 'FileEntry
       :defs $ {}
-        |get-dylib-ext $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |get-dylib-ext $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro get-dylib-ext () $ case-default (&get-os) |.so (:macos |.dylib) (:windows |.dll)
           :examples $ []
-        |get-dylib-path $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Macro
+            {} (:return 'String)
+              :args $ []
+        |get-dylib-path $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn get-dylib-path (p)
               str (or-current-path calcit-dirname) p $ get-dylib-ext
           :examples $ []
-        |or-current-path $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Fn
+            {} (:return 'String)
+              :args $ [] 'String
+        |or-current-path $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn or-current-path (p)
               if (blank? p) |. p
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Fn
+            {} (:return 'String)
+              :args $ [] 'String
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns http.util $ :require
             http.$meta :refer $ calcit-dirname calcit-filename


### PR DESCRIPTION
## Summary
- canonicalize the Calcit snapshot and entries
- add concrete schemas for all non-FFI helpers
- retain dynamic request/response maps at the native FFI boundary
- add caps, format, snapshot, and static-analysis CI gates

## Verification
- caps --ci
- cr calcit.cirru --check-only
- cr calcit.cirru --entry server --check-only
- cargo build --release
- cr calcit.cirru

The native HTTP request/response contract remains dynamic until it has named application-level data definitions; its four boundary slots are explicitly reported by the type baseline.