### PR TITLE
chore: upgrade Calcit to 0.13.15

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,3 @@
 
-{}
-  :calcit-version |0.13.13
-  :deps $ []
+{} (:calcit-version |0.13.15)
+  :dependencies $ {}


### PR DESCRIPTION
Bump calcit-version 0.13.13 → 0.13.15. check-only passes.